### PR TITLE
ActiveRecordEventSubscriber missing methods - fix #3

### DIFF
--- a/lib/debugbar/subscribers/active_record.rb
+++ b/lib/debugbar/subscribers/active_record.rb
@@ -60,6 +60,27 @@ module Debugbar
       def query_source_location
         backtrace_cleaner.clean(caller(3))[0]
       end
+
+      private
+
+      def type_casted_binds(casted_binds)
+        casted_binds.respond_to?(:call) ? casted_binds.call : casted_binds
+      end
+
+      def render_bind(attr, value)
+        case attr
+        when ActiveModel::Attribute
+          if attr.type.binary? && attr.value
+            value = "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
+          end
+        when Array
+          attr = attr.first
+        else
+          attr = nil
+        end
+
+        [attr&.name, value]
+      end
     end
   end
 end


### PR DESCRIPTION
This class is mostly (copy-pasted from Rails)[https://github.com/rails/rails/blob/main/activerecord/lib/active_record/log_subscriber.rb] and reformatted for my needs. I forgot 2 private methods.

I'm not sure how to get `binds` in my events. I never got them on my (demo app)[https://github.com/julienbourdeau/rails-demo-blog-app].