### PR TITLE
Require tag_helper.rb module explicitly

### DIFF
--- a/lib/debugbar/engine.rb
+++ b/lib/debugbar/engine.rb
@@ -1,5 +1,6 @@
 require_relative 'config'
 require_relative 'middlewares/track_current_request'
+require_relative '../../app/helpers/debugbar/tag_helpers'
 
 module Debugbar
   class Engine < ::Rails::Engine


### PR DESCRIPTION
This should mitigate #2 

I'd like to understand why this didn't happen to me. 
The `app/` folder should be added to autoload paths when the engine is loaded. Since this is inside the Engine class, I can understand why you need to require it explictly but didn't I get this error? 🤔 