### PR TITLE
Remove sql binds until I know how to test it

### DIFF
--- a/lib/debugbar/subscribers/active_record.rb
+++ b/lib/debugbar/subscribers/active_record.rb
@@ -22,26 +22,9 @@ module Debugbar
         sql = payload[:sql]&.gsub(/\/\*.*\*\//, "") # remove comments
 
         binds = nil
-        if payload[:binds]&.any?
-          casted_params = type_casted_binds(payload[:type_casted_binds])
-
-          binds = []
-          payload[:binds].each_with_index do |attr, i|
-            attribute_name = if attr.respond_to?(:name)
-              attr.name
-            elsif attr.respond_to?(:[]) && attr[i].respond_to?(:name)
-              attr[i].name
-            else
-              nil
-            end
-
-            filtered_params = filter(attribute_name, casted_params[i])
-
-            binds << render_bind(attr, filtered_params)
-          end
-          binds = binds.inspect
-          binds.prepend("  ")
-        end
+        # if payload[:binds]&.any?
+        #   TODO: Restore binds when I can figure out how to get something in poayload[:binds]
+        # end
 
         Debugbar::Tracker.add_query({
           id: event.transaction_id,
@@ -59,27 +42,6 @@ module Debugbar
 
       def query_source_location
         backtrace_cleaner.clean(caller(3))[0]
-      end
-
-      private
-
-      def type_casted_binds(casted_binds)
-        casted_binds.respond_to?(:call) ? casted_binds.call : casted_binds
-      end
-
-      def render_bind(attr, value)
-        case attr
-        when ActiveModel::Attribute
-          if attr.type.binary? && attr.value
-            value = "<#{attr.value_for_database.to_s.bytesize} bytes of binary data>"
-          end
-        when Array
-          attr = attr.first
-        else
-          attr = nil
-        end
-
-        [attr&.name, value]
       end
     end
   end


### PR DESCRIPTION
This code is mostly [copy-pasted from Rails](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/log_subscriber.rb).

Unfortunately, I'm not sure how to get `payload[:binds]` populated so I never tested this snippet. Like any code you haven't ran or tested yourself, it doesn't work 😄 

I'm removing it for now. It's also unused in the frontend because I didn't know what was there.

See #4,  #7.