### PR TITLE
Persist debugbar content after turbo page load

### DIFF
--- a/app/helpers/debugbar/tag_helpers.rb
+++ b/app/helpers/debugbar/tag_helpers.rb
@@ -7,20 +7,12 @@ module Debugbar::TagHelpers
       opt[:mode] = 'poll'
     end
 
-    html = <<-HTML
-      <div id="__debugbar"></div>
-    HTML
-
-    html += <<-HTML
+    raw(<<~HTML)
+      <div id="__debugbar" data-turbo-permanent></div>
       <script type="text/javascript">
         window._debugbarConfigOptions = #{opt.to_json}
       </script>
-    HTML
-
-    html += <<-HTML
       <script defer src="#{Debugbar.config.prefix}/assets/script"></script>
-      HTML
-
-    raw html
+    HTML
   end
 end


### PR DESCRIPTION
Fixes #9 based on [this suggestion](https://github.com/julienbourdeau/debugbar/issues/9#issuecomment-1994471659) by @hss-mateus.

## Problem

When turbo-rails gem and Turbo 8 is added to a Rails app, the debugbar doesn't always appear after navigating to a page.

## Why this is happening

Turbo fetches the page in the background as soon as we hover over a link, so that it can replace the page quickly on click, and make the interaction seem faster. However, debugbar broadcasts the debug information as soon as the request is processed.

If the click and the page replacement after before the debug information is broadcast, debugbar would have already replaced the content of `<div id="__debugbar">` with the new metrics, which will then be replaced by the empty div from the preloaded response.

## Proposed solution

I added the `data-turbo-permanent` attribute ([docs](https://turbo.hotwired.dev/handbook/building#persisting-elements-across-page-loads)) to the `__debugbar` div, which tells Turbo to keep the contents of the div when replacing the DOM.