### PR TITLE
Better support for Turbo Drive (Breaking Change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.3.0 - 2024-03-30
+
+* Add support for Turbo Drive - See [#25](https://github.com/julienbourdeau/debugbar/pull/25) and [#26](https://github.com/julienbourdeau/debugbar/pull/26)
+* 
+
 ## v0.2.0 - 2024-02-28
 
 * Introduce polling in case someone cannot use ActiveCable - See [8b262be7](https://github.com/julienbourdeau/debugbar/commit/8b262be7b644c7b587a6c3348bb02076053a344f)

--- a/app/helpers/debugbar/tag_helpers.rb
+++ b/app/helpers/debugbar/tag_helpers.rb
@@ -1,5 +1,11 @@
 module Debugbar::TagHelpers
-  def debugbar_javascript(opt = {})
+  def debugbar_head
+    raw <<-HTML
+      <script defer src="#{Debugbar.config.prefix}/assets/script"></script>
+    HTML
+  end
+
+  def debugbar_body(opt = {})
     opt = ActiveSupport::HashWithIndifferentAccess.new(opt)
 
     # See https://github.com/julienbourdeau/debugbar/issues/8
@@ -7,12 +13,25 @@ module Debugbar::TagHelpers
       opt[:mode] = 'poll'
     end
 
-    raw(<<~HTML)
+    html = <<-HTML
       <div id="__debugbar" data-turbo-permanent></div>
-      <script type="text/javascript">
+    HTML
+
+    html += <<-HTML
+      <script type="text/javascript" data-turbo-permanent>
         window._debugbarConfigOptions = #{opt.to_json}
       </script>
-      <script defer src="#{Debugbar.config.prefix}/assets/script"></script>
     HTML
+
+    raw html
+  end
+
+  def debugbar_javascript(opt = {})
+    errors = []
+    errors << "debugbar_javascript was removed in 0.3.0."
+    errors << "Please use `debugbar_head` inside <head> and `debugbar_body(opt_hash)` at the end of <body> instead."
+    errors << "It was split to support Turbo Drive."
+    errors << "See https://debugbar.dev/changelog/ for more information."
+    raise errors.join("\n")
   end
 end


### PR DESCRIPTION
Loading the javascript inside the body caused it to be re-executed when using Turbo Drive navigation.

![CleanShot 2024-03-30 at 11 52 24@2x](https://github.com/julienbourdeau/debugbar/assets/1525636/839b66ff-010c-4de5-ad50-fb5255e6c760)


The `#__debugbar` element uses `data-turbo-permanent` to not be reloaded, see #25 

And the js file is loaded inside the `head` element. 
I'm a little bit scared that it doesn't work well if the js is loaded before `#__debugbar` exists in the dom 🤔 


The `debugbar_javascript` helper is now split into 2 helpers:
- `debugbar_head` for the <head>
- `debugbar_body` for the <body>
