### PR TITLE
Fix skip_before_action :verify_authenticity_token not found error if protect_from_forgery is disabled

### DIFF
--- a/app/controllers/debugbar/polling_controller.rb
+++ b/app/controllers/debugbar/polling_controller.rb
@@ -1,6 +1,6 @@
 module Debugbar
   class PollingController < ApplicationController
-    skip_before_action :verify_authenticity_token, only: [:confirm], if: -> { self.respond_to?(:verify_authenticity_token, true) }
+    protect_from_forgery with: :null_session
     before_action :cors_set_access_control_headers
 
     def poll

--- a/app/controllers/debugbar/polling_controller.rb
+++ b/app/controllers/debugbar/polling_controller.rb
@@ -1,6 +1,6 @@
 module Debugbar
   class PollingController < ApplicationController
-    skip_before_action :verify_authenticity_token, only: [:confirm]
+    skip_before_action :verify_authenticity_token, only: [:confirm], if: -> { self.respond_to?(:verify_authenticity_token, true) }
     before_action :cors_set_access_control_headers
 
     def poll


### PR DESCRIPTION
See #23 