### PR TITLE
Handle cluster mode for Puma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Handle multi-processes service (cluster mode in Puma) - See [#45](https://github.com/julienbourdeau/debugbar/pull/45)
+
 ## v0.3.3 - 2024-06-15
 
 * Allow nonce to be set for content security policies - See [#38](https://github.com/julienbourdeau/debugbar/pull/38)

--- a/app/channels/debugbar/debugbar_channel.rb
+++ b/app/channels/debugbar/debugbar_channel.rb
@@ -13,13 +13,11 @@ module Debugbar
         RequestBuffer.remove(data["ids"])
       end
 
-      Debugbar.connect!
-
       ActionCable.server.broadcast("debugbar_channel", RequestBuffer.to_h)
     end
 
     def unsubscribed
-      Debugbar.disconnect!
+      # Nothing to do
     end
   end
 end

--- a/app/channels/debugbar/debugbar_channel.rb
+++ b/app/channels/debugbar/debugbar_channel.rb
@@ -15,8 +15,7 @@ module Debugbar
 
       Debugbar.connect!
 
-      data = RequestBuffer.all.map(&:to_h)
-      ActionCable.server.broadcast("debugbar_channel", data)
+      ActionCable.server.broadcast("debugbar_channel", RequestBuffer.to_h)
     end
 
     def unsubscribed

--- a/lib/debugbar.rb
+++ b/lib/debugbar.rb
@@ -69,18 +69,6 @@ module Debugbar
       yield config
     end
 
-    def connect!
-      @connected = true
-    end
-
-    def disconnect!
-      @connected = false
-    end
-
-    def connected?
-      @connected
-    end
-
     def msg(msg, *extra)
       source = caller.first&.split(":in")&.map { |s| s.delete_prefix("#{Rails.root}/").strip.tr("`'", '' ) }
       Tracker.msg(msg, extra, source)

--- a/lib/debugbar/buffers/cache_buffer.rb
+++ b/lib/debugbar/buffers/cache_buffer.rb
@@ -4,7 +4,6 @@ module Debugbar
       collection = get_collection
       collection[request.id] = request.to_h
       set_collection(collection)
-      nil
     end
 
     def remove(ids)
@@ -15,22 +14,19 @@ module Debugbar
         collection.delete(id)
       end
       set_collection(collection)
-
-      :self
     end
 
-    def all
-      get_collection.values
+    def to_h
+      get_collection.values.map(&:to_h)
     end
 
     def each(&block)
       get_collection.each(&block)
-      :self
+
     end
 
     def clear!
       Rails.cache.delete("debugbar-requests")
-      :self
     end
 
     private

--- a/lib/debugbar/buffers/cache_buffer.rb
+++ b/lib/debugbar/buffers/cache_buffer.rb
@@ -1,0 +1,46 @@
+module Debugbar
+  class CacheBuffer
+    def push(request)
+      collection = get_collection
+      collection[request.id] = request.to_h
+      set_collection(collection)
+      nil
+    end
+
+    def remove(ids)
+      ids = Array.wrap(ids)
+
+      collection = get_collection
+      ids.each do |id|
+        collection.delete(id)
+      end
+      set_collection(collection)
+
+      :self
+    end
+
+    def all
+      get_collection.values
+    end
+
+    def each(&block)
+      get_collection.each(&block)
+      :self
+    end
+
+    def clear!
+      Rails.cache.delete("debugbar-requests")
+      :self
+    end
+
+    private
+
+    def get_collection
+      Rails.cache.fetch("debugbar-requests") { {} }
+    end
+
+    def set_collection(collection)
+      Rails.cache.write("debugbar-requests", collection)
+    end
+  end
+end

--- a/lib/debugbar/buffers/memory_buffer.rb
+++ b/lib/debugbar/buffers/memory_buffer.rb
@@ -6,7 +6,6 @@ module Debugbar
 
     def push(request)
       @collection[request.id] = request
-      nil
     end
 
     def remove(ids)
@@ -14,21 +13,18 @@ module Debugbar
       ids.each do |id|
         @collection.delete(id)
       end
-      :self
     end
 
-    def all
-      @collection.values
+    def to_h
+      @collection.values.map(&:to_h)
     end
 
     def each(&block)
       @collection.each(&block)
-      :self
     end
 
     def clear!
       @collection = {}
-      :self
     end
   end
 end

--- a/lib/debugbar/buffers/null_buffer.rb
+++ b/lib/debugbar/buffers/null_buffer.rb
@@ -6,7 +6,8 @@ module Debugbar
     def remove(_ids)
     end
 
-    def all
+    def to_h
+      {}
     end
 
     def each

--- a/lib/debugbar/buffers/request_buffer.rb
+++ b/lib/debugbar/buffers/request_buffer.rb
@@ -5,6 +5,7 @@ module Debugbar
         @adapter = adapter
       end
 
+      # Maybe making this explicit is better :D
       %w(push each all remove clear!).each do |name|
         define_method(name) do |*args, &block|
           ret = @adapter.send(name, *args, &block)

--- a/lib/debugbar/buffers/request_buffer.rb
+++ b/lib/debugbar/buffers/request_buffer.rb
@@ -5,12 +5,28 @@ module Debugbar
         @adapter = adapter
       end
 
-      # Maybe making this explicit is better :D
-      %w(push each all remove clear!).each do |name|
-        define_method(name) do |*args, &block|
-          ret = @adapter.send(name, *args, &block)
-          ret == :self ? self : ret
-        end
+      def push(request)
+        @adapter.push(request)
+        nil # Why not return self?
+      end
+
+      def remove(ids)
+        @adapter.remove(ids)
+        self
+      end
+
+      def to_h
+        @adapter.to_h
+      end
+
+      def each(&block)
+        @adapter.each(&block)
+        self
+      end
+
+      def clear!
+        @adapter.clear!
+        self
       end
     end
   end

--- a/lib/debugbar/engine.rb
+++ b/lib/debugbar/engine.rb
@@ -12,6 +12,29 @@ module Debugbar
     end
 
     initializer 'debugbar.init' do |app|
+      # Display error message if running in multi-process mode without proper configuration
+      if ENV["WEB_CONCURRENCY"].to_i > 1
+        cache_nok = %i[null_store memory_store].include?(Rails.configuration.cache_store.first.to_sym)
+        action_cable_nok = ActionCable.server.config.cable[:adapter].to_s == "async"
+        adapter_nok = app.config.debugbar.buffer_adapter != :cache
+
+        if cache_nok || action_cable_nok || adapter_nok
+          msg = [
+            "############################################################################################################",
+            "# Debugbar: You are using a multi-process server configuration (like Puma in cluster mode)",
+            "# Debugbar: You can use puma in single mode by setting the environment variable WEB_CONCURRENCY to 0",
+            "# Debugbar: If you want to use multiple processes, you must ensure that the following conditions are met:",
+            "# Debugbar: \t Use a persistent cache store (like files or database) in your Application config",
+            "# Debugbar: \t Use a persistent adapter for ActionCable (like Redis or SolidCable)",
+            "# Debugbar: \t Use the :cache buffer_adapter in config/initializers/debugbar.rb",
+            "############################################################################################################",
+          ]
+
+          logger = Logger.new(STDOUT)
+          msg.each { |m| logger.warn(m) }
+        end
+      end
+
       adapter = case(app.config.debugbar.buffer_adapter)
       when :cache
         require_relative 'buffers/cache_buffer'

--- a/lib/debugbar/engine.rb
+++ b/lib/debugbar/engine.rb
@@ -13,6 +13,9 @@ module Debugbar
 
     initializer 'debugbar.init' do |app|
       adapter = case(app.config.debugbar.buffer_adapter)
+      when :cache
+        require_relative 'buffers/cache_buffer'
+        CacheBuffer.new
       when :memory
         require_relative 'buffers/memory_buffer'
         MemoryBuffer.new

--- a/lib/debugbar/middlewares/track_current_request.rb
+++ b/lib/debugbar/middlewares/track_current_request.rb
@@ -24,7 +24,7 @@ module Debugbar
         RequestBuffer.push(Debugbar::Current.pop_request!)
 
         # TODO: Refactor since not having ActionCable might be more common than I thought
-        if Debugbar.connected? && defined?(ActionCable)
+        if defined?(ActionCable)
           ActionCable.server.broadcast("debugbar_channel", RequestBuffer.to_h)
         end
       end


### PR DESCRIPTION
It's recommended to use the debugbar with puma (or similar) running into a single process (single mode). If for some reason, you're stuck with using cluster mode in dev, this feature is for you. I think one good reason is to have a dev env as close as production as possible.

By default, all requests are stored in memory. Once you have multiple processes, each processes hold their list of request and isolated memories. This PR introduce a new way to store requests using `Rails.cache` so each process are accessing the same list.

The same way, ActionCable runs with `async` driver by default which holds the connections in memory. It's also incompatible with cluster mode, the `cable.yml` needs to be edited to use Redis, memcache or SolidCable.
I'd typically use the same configuration in `development` and `production`.

I'm displaying an error message because when I started working on the debugbar, I was using cluster mode locally and couldn't figure out why some requests "got lost". I probably **wasted freaking hours** on this!

![CleanShot 2024-12-29 at 11 47 30@2x](https://github.com/user-attachments/assets/58567510-ed06-4521-86c4-6dfd4f519e65)
