### PR TITLE
Track HTTP requests made from the backend (using `httplog` gem)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Handle multi-processes service (cluster mode in Puma) - See [#45](https://github.com/julienbourdeau/debugbar/pull/45)
 * Ignore OPTIONS requests - See [08e7ee06](https://github.com/julienbourdeau/debugbar/commit/08e7ee0665f18f419a9a9bbcea00c414d05c2084)
 * ⚠️ Automatically set `action_cable.disable_request_forgery_protection` to true - See [449fc496](https://github.com/julienbourdeau/debugbar/commit/449fc49691182ecedf7cbbe1e5ca276894a70fee)
+* Some design tweak (like the select input to choose the request)
 
 ## v0.3.3 - 2024-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## UNRELEASED
 
+* Track HTTP calls made by Rails - See [#48](https://github.com/julienbourdeau/debugbar/pull/48)
 * Handle multi-processes service (cluster mode in Puma) - See [#45](https://github.com/julienbourdeau/debugbar/pull/45)
 * Ignore OPTIONS requests - See [08e7ee06](https://github.com/julienbourdeau/debugbar/commit/08e7ee0665f18f419a9a9bbcea00c414d05c2084)
-* Automatically set `action_cable.disable_request_forgery_protection` to true - See [449fc496](https://github.com/julienbourdeau/debugbar/commit/449fc49691182ecedf7cbbe1e5ca276894a70fee)
+* ⚠️ Automatically set `action_cable.disable_request_forgery_protection` to true - See [449fc496](https://github.com/julienbourdeau/debugbar/commit/449fc49691182ecedf7cbbe1e5ca276894a70fee)
 
 ## v0.3.3 - 2024-06-15
 

--- a/build_fixtures.rb
+++ b/build_fixtures.rb
@@ -8,7 +8,7 @@ Dir.glob("#{fixtures_dir}/*").each { |p| File.delete(p) }
 
 Net::HTTP.start('127.0.0.1', 3000) do |http|
   [
-    '/post-list',
+    '/post-list?with-external-data=true',
     '/slow-page',
     '/random',
     '/post/240',
@@ -29,4 +29,3 @@ Net::HTTP.start('127.0.0.1', 3000) do |http|
     File.write("#{fixtures_dir}/#{name}.json", JSON.pretty_generate(item))
   end
 end
-

--- a/client/src/AppDev.vue
+++ b/client/src/AppDev.vue
@@ -34,6 +34,14 @@ onMounted(() => {
       mode: "no-cors",
     })
   }, 600)
+
+  //   setTimeout(() => {
+  //     // We use `no-cors` mode because we don't need the response, we just want to trigger the request,
+  //     // fetch("http://127.0.0.1:3000/topics", { mode: "no-cors" })
+  //     fetch("http://127.0.0.1:3000/topics/random", { mode: "no-cors" })
+  //     // fetch("http://127.0.0.1:3000/topics/slow", { mode: "no-cors" })
+  //     fetch("http://127.0.0.1:3000/external-data?use_params=yes", { mode: "no-cors" })
+  //   }, 600)
 })
 </script>
 

--- a/client/src/AppDevtoolsDev.vue
+++ b/client/src/AppDevtoolsDev.vue
@@ -43,6 +43,14 @@ onMounted(() => {
       },
     })
   }, 800)
+
+  // setTimeout(() => {
+  //   // We use `no-cors` mode because we don't need the response, we just want to trigger the request,
+  //   // fetch("http://127.0.0.1:3000/topics", { mode: "no-cors" })
+  //   fetch("http://127.0.0.1:3000/topics/random", { mode: "no-cors" })
+  //   // fetch("http://127.0.0.1:3000/topics/slow", { mode: "no-cors" })
+  //   fetch("http://127.0.0.1:3000/external-data?use_params=yes", { mode: "no-cors" })
+  // }, 600)
 })
 </script>
 

--- a/client/src/DebugbarBody.vue
+++ b/client/src/DebugbarBody.vue
@@ -9,6 +9,7 @@ import RequestPanel from "@/components/panels/RequestPanel.vue"
 import MessageItem from "@/components/messages/MessageItem.vue"
 import ModelsPanel from "@/components/panels/ModelsPanel.vue"
 import { BackendRequest } from "@/models/Request.ts"
+import HttpPanel from "@/components/panels/HttpPanel.vue"
 
 withDefaults(
   defineProps<{
@@ -21,7 +22,6 @@ withDefaults(
 
 <template>
   <div ref="body" id="debugbar-body" class="bg-white overflow-scroll">
-    <request-panel v-if="activeTab == 'request'" :request="request" />
     <panel-list v-if="activeTab == 'messages'">
       <message-item v-for="msg in request?.messages" :msg="msg" :key="msg.id" />
     </panel-list>
@@ -32,6 +32,8 @@ withDefaults(
     <jobs-panel v-if="activeTab == 'jobs'" :jobs="request?.jobs" />
     <cache-panel v-if="activeTab == 'cache'" :cache="request?.cache" />
     <logs-panel v-if="activeTab == 'logs'" :logs="request?.logs" />
+    <http-panel v-if="activeTab == 'http'" :requests="request.httpCalls" />
+    <request-panel v-if="activeTab == 'request'" :request="request" />
     <json-panel v-if="activeTab == 'debug'" :request="request" class="px-3 py-2" />
   </div>
 </template>

--- a/client/src/components/panels/HttpPanel.vue
+++ b/client/src/components/panels/HttpPanel.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { HttpCall } from "@/models/Request.ts"
+import HttpRequestPanel from "@/components/panels/HttpRequestPanel.vue"
+import HttpResponsePanel from "@/components/panels/HttpResponsePanel.vue"
+import { ChevronDownIcon } from "@heroicons/vue/16/solid"
+import { reactive } from "vue"
+import HttpVerb from "@/components/ui/HttpVerb.vue"
+import { extractAfterPath } from "@/helpers.ts"
+import StatusCode from "@/components/ui/StatusCode.vue"
+
+defineProps<{
+  requests: HttpCall[]
+}>()
+
+const state = reactive({
+  idOpen: "",
+})
+</script>
+
+<template>
+  <div v-for="req in requests" :key="req.id">
+    <h1
+      class="flex items-center my-4 mx-2 space-x-2 px-2 py-2.5 bg-stone-100 border border-stone-300 tracking-wide text-sm rounded cursor-pointer"
+      @click="state.idOpen = state.idOpen === req.id ? '' : req.id"
+    >
+      <chevron-down-icon
+        class="size-4"
+        :class="{
+          '-rotate-90': state.idOpen !== req.id,
+        }"
+      />
+      <status-code :code="req.response?.status" />
+      <http-verb :verb="req.request.method" />
+      <span class="">
+        <span class="text-black font-bold">{{ req.request.url.pathname }}</span>
+        <span class="text-stone-600">{{ extractAfterPath(req.request.url) }}</span>
+      </span>
+    </h1>
+
+    <div v-if="state.idOpen == req.id" class="flex">
+      <http-request-panel :request="req.request" class="w-1/2" />
+      <http-response-panel :response="req.response" class="w-1/2" />
+    </div>
+  </div>
+</template>

--- a/client/src/components/panels/HttpPanel.vue
+++ b/client/src/components/panels/HttpPanel.vue
@@ -13,7 +13,7 @@ defineProps<{
 }>()
 
 const state = reactive({
-  idOpen: "",
+  open: {},
 })
 </script>
 
@@ -21,12 +21,12 @@ const state = reactive({
   <div v-for="req in requests" :key="req.id">
     <h1
       class="flex items-center my-4 mx-2 space-x-2 px-2 py-2.5 bg-stone-100 border border-stone-300 tracking-wide text-sm rounded cursor-pointer"
-      @click="state.idOpen = state.idOpen === req.id ? '' : req.id"
+      @click="state.open[req.id] = !state.open[req.id]"
     >
       <chevron-down-icon
         class="size-4"
         :class="{
-          '-rotate-90': state.idOpen !== req.id,
+          '-rotate-90': state.open[req.id],
         }"
       />
       <status-code :code="req.response?.status" />
@@ -37,7 +37,7 @@ const state = reactive({
       </span>
     </h1>
 
-    <div v-if="state.idOpen == req.id" class="flex">
+    <div v-if="state.open[req.id]" class="flex">
       <http-request-panel :request="req.request" class="w-1/2" />
       <http-response-panel :response="req.response" class="w-1/2" />
     </div>

--- a/client/src/components/panels/HttpRequestPanel.vue
+++ b/client/src/components/panels/HttpRequestPanel.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import Panel from "@/components/panels/Panel.vue"
+import Row from "@/components/ui/Row.vue"
+import KeyValueTable from "@/components/ui/KeyValueTable.vue"
+import Foldable from "@/components/ui/Foldable.vue"
+import { HttpRequest } from "@/models/Request.ts"
+import JsonCode from "@/components/ui/JsonCode.vue"
+import SubHeading from "@/components/ui/SubHeading.vue"
+import HttpVerb from "@/components/ui/HttpVerb.vue"
+import { extractQueryParams } from "@/helpers.ts"
+
+defineProps<{
+  request: HttpRequest
+}>()
+</script>
+
+<template>
+  <panel>
+    <sub-heading>HTTP Request</sub-heading>
+
+    <key-value-table>
+      <row label="Method"><http-verb :verb="request.method" /></row>
+      <row label="URL" class="font-mono">{{ request.url.href }}</row>
+      <row label="Params">
+        <json-code :json="extractQueryParams(request.url)" />
+      </row>
+      <row label="Header: Version">
+        {{ request.headers["Version"] }}
+      </row>
+      <row label="Header: Cache-Control">
+        {{ request.headers["Cache-Control"] }}
+      </row>
+    </key-value-table>
+
+    <foldable class="py-4" label="All Headers">
+      <key-value-table>
+        <row v-for="(v, k) in request.headers" :key="k" :label="k as unknown as string">{{ v }}</row>
+      </key-value-table>
+    </foldable>
+  </panel>
+</template>

--- a/client/src/components/panels/HttpResponsePanel.vue
+++ b/client/src/components/panels/HttpResponsePanel.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { HttpResponse } from "@/models/Request.ts"
+import Panel from "@/components/panels/Panel.vue"
+import KeyValueTable from "@/components/ui/KeyValueTable.vue"
+import Row from "@/components/ui/Row.vue"
+import Foldable from "@/components/ui/Foldable.vue"
+import SubHeading from "@/components/ui/SubHeading.vue"
+import StatusCode from "@/components/ui/StatusCode.vue"
+
+defineProps<{
+  response: HttpResponse
+}>()
+</script>
+
+<template>
+  <panel>
+    <sub-heading>HTTP Response</sub-heading>
+
+    <key-value-table>
+      <row label="Status"><status-code :code="response.status" /></row>
+      <row label="Body">{{ response.body.substring(0, 140) }}</row>
+      <row label="Header: Content-Type">
+        {{ response.headers["Content-Type"] }}
+      </row>
+    </key-value-table>
+
+    <foldable class="py-4" label="All Headers">
+      <key-value-table>
+        <row v-for="(v, k) in response.headers" :key="k" :label="k as unknown as string">{{ v }}</row>
+      </key-value-table>
+    </foldable>
+  </panel>
+</template>

--- a/client/src/components/panels/RequestPanel.vue
+++ b/client/src/components/panels/RequestPanel.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import omit from "lodash/omit"
 import Panel from "@/components/panels/Panel.vue"
 import { BackendRequest } from "@/models/Request.ts"
 import KeyValueTable from "@/components/ui/KeyValueTable.vue"
 import Row from "@/components/ui/Row.vue"
-import Foldable from "@/components/ui/Foldable.vue"
+import SubHeading from "@/components/ui/SubHeading.vue"
+import HttpResponsePanel from "@/components/panels/HttpResponsePanel.vue"
+import HttpRequestPanel from "@/components/panels/HttpRequestPanel.vue"
 
 defineProps<{
   request: BackendRequest
@@ -14,85 +15,37 @@ defineProps<{
 <template>
   <div class="flex">
     <div class="w-1/2">
-      <panel>
-        <h2 class="mt-0.5 mb-2 px-2 py-1 bg-stone-300 text-black tracking-wide text-xs uppercase font-bold rounded">
-          HTTP Request
-        </h2>
-
-        <key-value-table>
-          <row label="Method">{{ request.meta.method }}</row>
-          <row label="URL">{{ request.meta.path }}</row>
-          <row label="Params">
-            <highlightjs
-              class="text-sm"
-              language="json"
-              :code="JSON.stringify(omit(request.meta.params, ['controller', 'action']), null, 2)"
-            />
-          </row>
-          <row label="Header: Version">
-            {{ request.request.headers["Version"] }}
-          </row>
-          <row label="Header: Cache-Control">
-            {{ request.request.headers["Cache-Control"] }}
-          </row>
-        </key-value-table>
-
-        <foldable class="py-4" label="All Headers">
-          <key-value-table>
-            <row v-for="(v, k) in request.request.headers" :key="k" :label="k as unknown as string">{{ v }}</row>
-          </key-value-table>
-        </foldable>
-
-        <div class="py-3 text-right italic text-sm text-stone-500">
-          What else would like to see here?
-          <a target="_blank" class="underline font-bold" href="https://github.com/julienbourdeau/debugbar/discussions"
-            >Tell me!</a
-          >
-        </div>
-      </panel>
+      <http-request-panel :request="request.request" />
     </div>
 
     <div class="w-1/2">
       <panel>
-        <h2 class="mt-0.5 mb-2 px-2 py-1 bg-stone-300 text-black tracking-wide text-xs uppercase font-bold rounded">
-          Routing
-        </h2>
+        <sub-heading>Routing</sub-heading>
 
         <key-value-table>
           <row title="Controller"> {{ request.meta.controller }} > {{ request.meta.action }} </row>
         </key-value-table>
       </panel>
 
-      <panel>
-        <h2 class="mt-0.5 mb-2 px-2 py-1 bg-stone-300 text-black tracking-wide text-xs uppercase font-bold rounded">
-          HTTP Response
-        </h2>
+      <http-response-panel v-if="request.response?.status" :response="request.response" />
 
-        <div v-if="!request.response?.status">
-          <div class="py-3 text-sm text-stone-500">
-            The response was not captured.
-            <a target="_blank" class="underline font-bold" href="https://debugbar.dev/docs/known-limitations/"
-              >Learn more</a
-            >
-          </div>
+      <div v-if="!request.response?.status">
+        <div class="py-3 text-sm text-stone-500">
+          The response was not captured.
+          <a target="_blank" class="underline font-bold" href="https://debugbar.dev/docs/known-limitations/"
+            >Learn more</a
+          >
         </div>
+      </div>
+    </div>
+  </div>
 
-        <div v-if="request.response?.status">
-          <key-value-table>
-            <row label="Status">{{ request.response.status }}</row>
-            <row label="Body">{{ request.response.body.substring(0, 140) }}</row>
-            <row label="Header: Content-Type">
-              {{ request.response.headers["Content-Type"] }}
-            </row>
-          </key-value-table>
-
-          <foldable class="py-4" label="All Headers">
-            <key-value-table>
-              <row v-for="(v, k) in request.response.headers" :key="k" :label="k as unknown as string">{{ v }}</row>
-            </key-value-table>
-          </foldable>
-        </div>
-      </panel>
+  <div class="w-full">
+    <div class="py-3 text-center italic text-sm text-stone-500">
+      What else would like to see here?
+      <a target="_blank" class="underline font-bold" href="https://github.com/julienbourdeau/debugbar/discussions"
+        >Tell me!</a
+      >
     </div>
   </div>
 </template>

--- a/client/src/components/ui/HttpVerb.vue
+++ b/client/src/components/ui/HttpVerb.vue
@@ -5,7 +5,7 @@ const props = defineProps<{
 </script>
 
 <template>
-  <div
+  <span
     class="px-1 py-0.5 rounded text-xs text-white bg-slate-700"
     :class="{
       '!bg-sky-700': props.verb.toLowerCase() == 'get',
@@ -15,5 +15,5 @@ const props = defineProps<{
       '!bg-red-700': props.verb.toLowerCase() == 'delete',
     }"
     v-text="props.verb.toUpperCase()"
-  ></div>
+  ></span>
 </template>

--- a/client/src/components/ui/RequestsDropdown.vue
+++ b/client/src/components/ui/RequestsDropdown.vue
@@ -3,6 +3,7 @@ import { ref, onMounted, onUnmounted, nextTick, computed } from "vue"
 import { BackendRequest } from "@/models/Request.ts"
 import HttpVerb from "@/components/ui/HttpVerb.vue"
 import { ChevronUpDownIcon } from "@heroicons/vue/16/solid"
+import { extractAfterPath } from "../../helpers.ts"
 
 const props = defineProps<{
   requests: BackendRequest[]
@@ -56,23 +57,6 @@ onUnmounted(() => {
   window.removeEventListener("scroll", updatePosition, true)
   window.removeEventListener("resize", updatePosition)
 })
-
-// Add this function to split the path
-const getPathParts = (request: BackendRequest) => {
-  const basePath = request.request.path
-  const fullPath = request.meta.path
-
-  // If they're the same, return the full path as the first part
-  if (basePath === fullPath) {
-    return { base: fullPath, params: "" }
-  }
-
-  // Otherwise split into base and params
-  return {
-    base: basePath,
-    params: fullPath.slice(basePath.length),
-  }
-}
 </script>
 
 <template>
@@ -84,8 +68,8 @@ const getPathParts = (request: BackendRequest) => {
     >
       <http-verb :verb="currentRequest.request.method" />
       <span class="truncate grow text-left">
-        <span class="text-stone-900">{{ getPathParts(currentRequest).base }}</span>
-        <span class="text-stone-500">{{ getPathParts(currentRequest).params }}</span>
+        <span class="text-stone-900">{{ currentRequest.request.url.pathname }}</span>
+        <span class="text-stone-500">{{ extractAfterPath(currentRequest.request.url) }}</span>
       </span>
       <chevron-up-down-icon class="size-4" :class="{ 'rotate-180': isOpen }" />
     </button>
@@ -109,8 +93,8 @@ const getPathParts = (request: BackendRequest) => {
         >
           <http-verb :verb="request.request.method" />
           <span class="">
-            <span class="text-stone-900">{{ getPathParts(request).base }}</span>
-            <span class="text-stone-500">{{ getPathParts(request).params }}</span>
+            <span class="text-stone-900">{{ request.request.url.pathname }}</span>
+            <span class="text-stone-500">{{ extractAfterPath(request.request.url) }}</span>
           </span>
         </button>
       </div>

--- a/client/src/components/ui/StatusCode.vue
+++ b/client/src/components/ui/StatusCode.vue
@@ -5,7 +5,7 @@ const props = defineProps<{
 </script>
 
 <template>
-  <div
+  <span
     class="px-1 py-0.5 rounded text-xs"
     :class="{
       'bg-green-600 text-white': props.code < 300,
@@ -14,7 +14,7 @@ const props = defineProps<{
       'bg-red-600 text-white': props.code >= 500,
     }"
     v-text="props.code"
-  ></div>
+  ></span>
 </template>
 
 <style scoped></style>

--- a/client/src/components/ui/SubHeading.vue
+++ b/client/src/components/ui/SubHeading.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts"></script>
+
+<template>
+  <h2 class="mt-0.5 mb-2 px-2 py-1 bg-stone-300 text-black tracking-wide text-xs uppercase font-bold rounded">
+    <slot />
+  </h2>
+</template>

--- a/client/src/helpers.ts
+++ b/client/src/helpers.ts
@@ -5,3 +5,16 @@ export function copyToClipboard(content: string | object) {
   const data = [new ClipboardItem({ [type]: blob })]
   navigator.clipboard.write(data)
 }
+
+export function extractAfterPath(url: URL): string {
+  const prefixLen = url.origin.length + url.pathname.length
+  return url.href.slice(prefixLen)
+}
+
+export function extractQueryParams(url: URL): object {
+  const params = {}
+  for (const [key, value] of url.searchParams) {
+    params[key] = value
+  }
+  return params
+}

--- a/client/src/models/Request.ts
+++ b/client/src/models/Request.ts
@@ -164,8 +164,8 @@ export class BackendRequest {
     }, []).length
   }
 
-  get pathWithVerb(): string {
-    return `${this.meta.method.toUpperCase()} ${this.meta.path}`
+  get httpCount(): number {
+    return this.httpCalls.length
   }
 
   get routeAlias(): string {
@@ -205,6 +205,7 @@ export class BackendRequest {
     if (this.httpCalls.length > 0) {
       tabs["http"] = {
         label: "Http",
+        count: this.httpCount,
       }
     }
 

--- a/client/src/models/Request.ts
+++ b/client/src/models/Request.ts
@@ -1,14 +1,15 @@
 export type BackendRequestData = {
   id: string
   meta: RequestMeta
-  request: RequestRequest
-  response: RequestResponse
+  request: HttpRequest
+  response: HttpResponse
   models: { [key: string]: number }
   queries: Query[]
   jobs: Job[]
   messages: Message[]
   cache: Cache[]
   logs: Log[]
+  http_calls: HttpCall[]
 }
 
 export type RequestMeta = {
@@ -27,15 +28,14 @@ export type RequestMeta = {
   allocations: number
 }
 
-export type RequestRequest = {
+export type HttpRequest = {
   method: string
-  path: string
-  format: string
+  url: URL
   headers: Headers
-  params: { [key: string]: any }
+  body: string
 }
 
-export type RequestResponse = {
+export type HttpResponse = {
   status: number
   headers: Headers
   body: string
@@ -91,17 +91,25 @@ export type Log = {
   progname: string
 }
 
+export type HttpCall = {
+  id: string
+  request: HttpRequest
+  response: HttpResponse
+  [key: string]: any
+}
+
 export class BackendRequest {
   id: string
   meta: RequestMeta
-  request: RequestRequest
-  response: RequestResponse
+  request: HttpRequest
+  response: HttpResponse
   models: { [key: string]: number }
   queries: Query[]
   jobs: Job[]
   messages: Message[]
   cache: Cache[]
   logs: Log[]
+  httpCalls: HttpCall[]
 
   constructor(data: BackendRequestData) {
     if (import.meta.env.DEV) {
@@ -110,14 +118,24 @@ export class BackendRequest {
 
     this.id = data?.id || "null"
     this.meta = data?.meta || ({} as unknown as RequestMeta)
-    this.request = data?.request || ({} as unknown as RequestRequest)
-    this.response = data?.response || ({} as unknown as RequestResponse)
+    this.request = {
+      ...data?.request,
+      url: data?.request?.url ? new URL(data?.request.url) : new URL("http://localhost"),
+    }
+    this.response = data?.response || ({} as unknown as HttpResponse)
     this.models = data?.models || {}
     this.queries = data?.queries || []
     this.jobs = data?.jobs || []
     this.messages = data?.messages || []
     this.cache = data?.cache || []
     this.logs = data?.logs || []
+    this.httpCalls = (data?.http_calls || []).map((call) => ({
+      ...call,
+      request: {
+        ...call.request,
+        url: call.request?.url ? new URL(call.request.url) : new URL("http://localhost"),
+      },
+    }))
   }
 
   get modelsCount(): number {
@@ -181,6 +199,12 @@ export class BackendRequest {
     if (this.logs.length > 0) {
       tabs["logs"] = {
         label: "Logs",
+      }
+    }
+
+    if (this.httpCalls.length > 0) {
+      tabs["http"] = {
+        label: "Http",
       }
     }
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -22,7 +22,8 @@
     "strict": false,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/lib/debugbar.rb
+++ b/lib/debugbar.rb
@@ -6,13 +6,16 @@ module Debugbar
   autoload :Request, "debugbar/request"
   autoload :RequestBuffer, "debugbar/buffers/request_buffer"
   autoload :SimpleLogger, "debugbar/loggers/simple_logger"
+  autoload :HttpLogger, "debugbar/loggers/http_logger"
+  autoload :HttpRequest, "debugbar/http/http"
+  autoload :HttpResponse, "debugbar/http/http"
 
   TIME_FORMAT = "%H:%M:%S.%L"
 
   module Tracker
     class << self
       SETTERS = %i[request response headers meta].freeze
-      METHODS = %i[inc_model add_query add_job add_cache add_log].freeze
+      METHODS = %i[inc_model add_query add_job add_cache add_log add_http_call].freeze
 
       SETTERS.each do |m|
         define_method("#{m}=") do |val|

--- a/lib/debugbar/engine.rb
+++ b/lib/debugbar/engine.rb
@@ -21,6 +21,27 @@ module Debugbar
         app.config.action_cable.disable_request_forgery_protection = true
         log "Debugbar: Action Cable request forgery protection is enabled. This can cause issues with Debugbar. Overriding setting config.action_cable.disable_request_forgery_protection = true now. Update your configuration to get rid of this message."
       end
+
+      if defined? HttpLog
+        HttpLog.configure do |config|
+          config.enabled = true
+
+          config.json_log = true
+          config.prefix = ''
+
+          config.logger = Debugbar::HttpLogger.new
+          config.logger_method = :log
+
+          config.log_connect   = true
+          config.log_request   = true
+          config.log_headers   = true
+          config.log_data      = true
+          config.log_status    = true
+          config.log_response  = true
+          config.log_benchmark = true
+
+        end
+      end
     end
 
     initializer 'debugbar.init' do |app|

--- a/lib/debugbar/http/http.rb
+++ b/lib/debugbar/http/http.rb
@@ -1,0 +1,44 @@
+module Debugbar
+  class HttpRequest
+    attr_reader :method, :url, :headers, :body
+
+    def initialize(method, url, headers, body)
+      @method = method
+      @url = url
+      @headers = headers
+      @body = body
+    end
+
+    def self.from_rack(rack_req)
+      headers = rack_req.env.select { |k,v| k.start_with? 'HTTP_'} # https://stackoverflow.com/a/55406700/1001125
+        .transform_keys { |k| k.sub(/^HTTP_/, '').split('_').map(&:capitalize).join('-') }
+        .sort.to_h
+
+      new(rack_req.method, rack_req.original_url, headers, rack_req.body)
+    end
+
+    def to_h
+      { method:, url:, headers:, body: }
+    end
+  end
+
+  class HttpResponse
+    attr_reader :status, :headers, :body
+
+    def initialize(status, headers, body)
+      @status = status
+      @headers = headers
+      @body = body
+    end
+
+    def self.from_rack(rack_res)
+      headers = rack_res.headers.to_h.transform_keys { |s| s.split('-').map(&:capitalize).join('-') }
+
+      new(rack_res.status, headers, rack_res.body)
+    end
+
+    def to_h
+      { status:, headers:, body: }
+    end
+  end
+end

--- a/lib/debugbar/loggers/http_logger.rb
+++ b/lib/debugbar/loggers/http_logger.rb
@@ -1,0 +1,20 @@
+module Debugbar
+  class HttpLogger < ::Logger
+    def initialize(min_level= 2)
+      @min_level = min_level
+    end
+
+    def log(_level, json_str)
+      # We normally rely on the Tracker to know if the current request is set or nil and log an error to STDOUT,
+      # but in this case, it happens so often that the logs are annoying.
+      # In ActiveCable, only the first call goes through the Rake middleware, so every following communication
+      # doesn't go through TrackCurrentRequest, which initializes the request.
+      return if ::Debugbar::Current.request.nil?
+
+      log = JSON.parse(json_str)
+      req = HttpRequest.new(log["method"], log["url"], log["request_headers"], log["request_body"])
+      res = HttpResponse.new(log["response_code"], log["response_headers"], log["response_body"])
+      Debugbar::Tracker.add_http_call(SecureRandom.hex(4), req, res, benchmark: log['benchmark'])
+    end
+  end
+end

--- a/lib/debugbar/subscribers/action_controller.rb
+++ b/lib/debugbar/subscribers/action_controller.rb
@@ -26,7 +26,6 @@ module Debugbar
         Debugbar::Tracker.request = request
         Debugbar::Tracker.response = response
         Debugbar::Tracker.meta = meta
-
       end
     end
   end


### PR DESCRIPTION
If the gem `httplog` is detected, the debugbar will configure a custom logger and start tracking HTTP calls maid by the backend.

All requests are shown in the "Http" tab of the bar. Calls are collapsed by default, click to open the details.

![CleanShot 2025-01-06 at 22 46 52@2x](https://github.com/user-attachments/assets/b89469ba-4acd-4280-89f2-2388ed8125cc)
