### PR TITLE
Fix: check for ActionCable before disable request forgery protection

### DIFF
--- a/lib/debugbar/engine.rb
+++ b/lib/debugbar/engine.rb
@@ -17,9 +17,11 @@ module Debugbar
     end
 
     initializer 'debugbar.override_config' do |app|
-      unless app.config.action_cable.disable_request_forgery_protection
-        app.config.action_cable.disable_request_forgery_protection = true
-        log "Debugbar: Action Cable request forgery protection is enabled. This can cause issues with Debugbar. Overriding setting config.action_cable.disable_request_forgery_protection = true now. Update your configuration to get rid of this message."
+      if defined? ActionCable
+        unless app.config.action_cable.disable_request_forgery_protection
+          app.config.action_cable.disable_request_forgery_protection = true
+          log "Debugbar: Action Cable request forgery protection is enabled. This can cause issues with Debugbar. Overriding setting config.action_cable.disable_request_forgery_protection = true now. Update your configuration to get rid of this message."
+        end
       end
 
       if defined? HttpLog


### PR DESCRIPTION
The [recent change](https://github.com/julienbourdeau/debugbar/commit/449fc49691182ecedf7cbbe1e5ca276894a70fee#diff-b649b89947efca18165b6c64a06e061ed7d8e13b6aebaa11421744e3ef486840R21) to automatically disable Action Cable request forgery protection assumes that Action Cable is available and throws an exception at startup when it is not (paths elided for readability):

```
.../railties-8.0.1/lib/rails/railtie/configuration.rb:109:in `method_missing': undefined method `action_cable' for an instance of Rails::Application::Configuration (NoMethodError)
        from .../debugbar-0.4.1/lib/debugbar/engine.rb:20:in `block in <class:Engine>'
```

This change just checks to see if ActionCable is defined first.