### PR TITLE
Add JSON validation before ActionCable broadcast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ public/debugbar.js
 
 package-lock.json
 Gemfile.lock
+.DS_Store

--- a/lib/debugbar/middlewares/track_current_request.rb
+++ b/lib/debugbar/middlewares/track_current_request.rb
@@ -25,8 +25,15 @@ module Debugbar
         RequestBuffer.push(Debugbar::Current.pop_request!)
 
         # TODO: Refactor since not having ActionCable might be more common than I thought
-        if defined?(ActionCable)
-          ActionCable.server.broadcast("debugbar_channel", RequestBuffer.to_h)
+        payload = RequestBuffer.to_h
+      
+        # Validate JSON-encodability before broadcast; skip if it would crash
+        begin
+          ActiveSupport::JSON.encode(payload)   # will raise on invalid UTF-8
+          ActionCable.server.broadcast("debugbar_channel", payload)
+        rescue JSON::GeneratorError
+          # Non-text/binary snuck into the payload (e.g. .xkt). Skip live update.
+          # (Everything else — header, request logging, X-Debugbar-Url — still works.)
         end
       end
 

--- a/lib/debugbar/version.rb
+++ b/lib/debugbar/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Debugbar
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end


### PR DESCRIPTION
Validate JSON-encodability of payload before broadcasting to ActionCable to prevent crashes from data formats that could not be encoded. for example xkt files